### PR TITLE
adds remove method to JsonDBTemplate without the EntityClass parameter

### DIFF
--- a/src/main/java/io/jsondb/JsonDBOperations.java
+++ b/src/main/java/io/jsondb/JsonDBOperations.java
@@ -560,6 +560,16 @@ public interface JsonDBOperations {
    * Remove the given object from the collection by id.
    *
    * @param objectToRemove  the object to remove from the collection
+   * @param <T> Type annotated with {@link io.jsondb.annotation.Document} annotation
+   *            and member of the baseScanPackage
+   * @return  the object that was actually removed or null
+   */
+  <T> T remove(Object objectToRemove);
+
+  /**
+   * Remove the given object from the collection by id.
+   *
+   * @param objectToRemove  the object to remove from the collection
    * @param entityClass  class that determines the collection to use
    * @param <T> Type annotated with {@link io.jsondb.annotation.Document} annotation
    *            and member of the baseScanPackage

--- a/src/main/java/io/jsondb/JsonDBTemplate.java
+++ b/src/main/java/io/jsondb/JsonDBTemplate.java
@@ -1002,6 +1002,14 @@ public class JsonDBTemplate implements JsonDBOperations {
   }
 
   /* (non-Javadoc)
+   * @see org.jsondb.JsonDBOperations#remove(java.lang.Object)
+   */
+  @Override
+  public <T> T remove(Object objectToRemove) {
+    return remove(objectToRemove, Util.determineEntityCollectionName(objectToRemove));
+  }
+
+  /* (non-Javadoc)
    * @see org.jsondb.JsonDBOperations#remove(java.lang.Object, java.lang.Class)
    */
   @Override

--- a/src/test/java/io/jsondb/tests/RemoveTests.java
+++ b/src/test/java/io/jsondb/tests/RemoveTests.java
@@ -142,7 +142,7 @@ public class RemoveTests {
    * Test to remove a single object from a collection
    */
   @Test
-  public void testRemove_ValidObject() {
+  public void testRemove_ValidObjectWithClass() {
     List<Instance> instances = jsonDBTemplate.getCollection(Instance.class);
     int size = instances.size();
 
@@ -150,6 +150,26 @@ public class RemoveTests {
     instance.setId("05");
 
     Instance removedObject = jsonDBTemplate.remove(instance, Instance.class);
+
+    instances = jsonDBTemplate.getCollection(Instance.class);
+    assertNotNull(instances);
+    assertEquals(size-1, instances.size());
+    assertNotNull(removedObject);
+    assertEquals("05", removedObject.getId());
+  }
+
+  /**
+   * Test to remove a single object from a collection
+   */
+  @Test
+  public void testRemove_ValidObjectWithoutClass() {
+    List<Instance> instances = jsonDBTemplate.getCollection(Instance.class);
+    int size = instances.size();
+
+    Instance instance = new Instance();
+    instance.setId("05");
+
+    Instance removedObject = jsonDBTemplate.remove(instance);
 
     instances = jsonDBTemplate.getCollection(Instance.class);
     assertNotNull(instances);


### PR DESCRIPTION
In analogy to upsert methods remove operation is not possible without giving the EntityClass.class parameter.