### PR TITLE
Use Java 8 as source and target versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ plugins {
 }
 
 apply plugin: "java"
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 apply plugin: "jacoco"
 apply plugin: "eclipse"
 apply plugin: "signing"


### PR DESCRIPTION
The current JSONDB version only runs under Java 10 because it was compiled with or for Java 10. In fact, there is no reason for this: JSONDB itself does not use Java features greater than 8 and even no dependencies require a higher Java version than 8. So only the source/targets settings prevents the use of JSONDB in environments where Java 8 is set.